### PR TITLE
Fix caching for pages not found (404 & 410)

### DIFF
--- a/root-files/opt/flownative/lib/nginx.sh
+++ b/root-files/opt/flownative/lib/nginx.sh
@@ -60,6 +60,7 @@ nginx_config_fastcgi_cache() {
            fastcgi_cache_methods GET HEAD;
            fastcgi_cache_key \$request_method\$scheme\$host\$request_uri;
            fastcgi_cache_valid 200 301 302 ${NGINX_CACHE_DEFAULT_LIFETIME};
+           fastcgi_cache_valid 404 410 30s;
            fastcgi_cache_use_stale ${NGINX_CACHE_USE_STALE_OPTIONS};
            fastcgi_cache_background_update ${NGINX_CACHE_BACKGROUND_UPDATE};
 


### PR DESCRIPTION
This fixes https://support.flownative.com/#ticket/zoom/6585 which is caused by the behaviour described in https://trac.nginx.org/nginx/ticket/1233 which I assume affects the fastcgi cache in the same way.

So this makes 404 and 410 responses cached for 30 seconds, to have such pages invalidated relatively quick, but also caching them for a bit longer, as it would usually be fine…