### PR TITLE
TASK: Tiny static file delivery improvements

### DIFF
--- a/root-files/opt/flownative/nginx/etc/nginx.conf.template
+++ b/root-files/opt/flownative/nginx/etc/nginx.conf.template
@@ -26,6 +26,11 @@ http {
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
+    
+    open_file_cache max=1000 inactive=20s;
+    open_file_cache_valid    30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors   on;
 
     map $$status $$status_is_enabled_for_access_log {
         ~${NGINX_ACCESS_LOG_IGNORED_STATUS_CODES_REGEX} 0;
@@ -87,7 +92,7 @@ http {
     gzip_comp_level 4;
     gzip_proxied any;
     gzip_vary off;
-    gzip_types text/plain text/css application/x-javascript text/xml application/xml application/rss+xml application/atom+xml text/javascript application/javascript application/json text/mathml image/svg+xml;
+    gzip_types text/plain text/html text/css application/x-javascript text/xml application/xml application/rss+xml application/atom+xml text/javascript application/javascript application/json text/mathml image/svg+xml application/x-font-ttf application/x-font-truetype font/ttf font/eot font/opentype;
     gzip_min_length  256;
     gzip_disable "MSIE [1-6]\.";
     gzip_static on;


### PR DESCRIPTION
Enables an open file cache to memory cache existence of static files, prevents frequent disc i/o on non existing files if they are requested repeatedly. Also adds some more mimetypes to the gzip allow list.